### PR TITLE
GCC crosscompile fixes

### DIFF
--- a/tinysound.h
+++ b/tinysound.h
@@ -358,7 +358,9 @@ void tsStopAllSounds( tsContext* ctx );
 
 	#include <dsound.h>
 	#undef PlaySound
-	#pragma comment( lib, "dsound.lib" )
+	#if defined(_MSC_VER)
+		#pragma comment( lib, "dsound.lib" )
+	#endif
 
 #elif TS_PLATFORM == TS_MAC
 
@@ -810,6 +812,7 @@ static void tsRemoveFilter( tsPlayingSound* playing );
 
 		LPDIRECTSOUND dsound;
 		HRESULT res = DirectSoundCreate( 0, &dsound, 0 );
+		if ( res != DS_OK ) return NULL;
 		dsound->lpVtbl->SetCooperativeLevel( dsound, (HWND)hwnd, DSSCL_PRIORITY );
 		DSBUFFERDESC bufdesc = { 0 };
 		bufdesc.dwSize = sizeof( bufdesc );
@@ -1618,8 +1621,6 @@ unlock:
 	tsUnlock( ctx );
 }
 
-#endif
-
 /*
 	zlib license:
 
@@ -1918,3 +1919,4 @@ static void smbPitchShift(float pitchShift, long numSampsToProcess, float sample
 		}
 	}
 }
+#endif


### PR DESCRIPTION
1. `#pragma comment( lib, "dsound.lib" )` is useful for Visual Studio only. GCC warning:
`warning: ignoring #pragma comment  [-Wunknown-pragmas]`
2. `HRESULT res = DirectSoundCreate( 0, &dsound, 0 );` if not check the `res` then there will be warning:
`warning: variable 'res' set but not used [-Wunused-but-set-variable]`
3. `#endif` of `TS_IMPLEMENTATION` moved to end of file