### PR TITLE
Fix assignment of structure

### DIFF
--- a/tinyc2.h
+++ b/tinyc2.h
@@ -1419,7 +1419,10 @@ static int c2SidePlanes( c2v* seg, c2x x, const c2Poly* p, int e, c2h* h )
 	c2h right = { in, c2Dot( in, rb ) };
 	if ( c2Clip( seg, left ) < 2 ) return 0;
 	if ( c2Clip( seg, right ) < 2 ) return 0;
-	if ( h ) *h = { c2CCW90( in ), c2Dot( c2CCW90( in ), ra ) };
+	if ( h ) {
+		h->n = c2CCW90( in );
+		h->d = c2Dot( c2CCW90( in ), ra );
+	}
 	return 1;
 }
 


### PR DESCRIPTION
The structure assignment on ```c2SidePlanes()``` was using aggregate
initialization for an assignment, which does not work for C (tested on
GCC 6.3.1, Linux). This commit fix that by assigning each member of the
structure to the new value.