### PR TITLE
Fix contact point in c2CircletoCircleManifold

### DIFF
--- a/tinyc2.h
+++ b/tinyc2.h
@@ -1171,10 +1171,11 @@ void c2CircletoCircleManifold( c2Circle A, c2Circle B, c2Manifold* m )
 	if ( d2 < r * r )
 	{
 		float l = c2Sqrt( d2 );
+		c2v n = l != 0 ? c2Mulvs( d, 1.0f / l ) : c2V( 0, 1.0f );
 		m->count = 1;
 		m->depths[ 0 ] = r - l;
-		m->contact_points[ 0 ] = c2Mulvs( c2Add( A.p, B.p ), 0.5f );
-		m->normal = l != 0 ? c2Mulvs( d, 1.0f / l ) : c2V( 0, 1.0f );
+		m->contact_points[ 0 ] = c2Sub( B.p, c2Mulvs( n, B.r ) );
+		m->normal = n;
 	}
 }
 


### PR DESCRIPTION
Contact point before:
![circle_wrong_contact](https://user-images.githubusercontent.com/17962301/27531221-235b39c6-5a5c-11e7-87da-a30fbf951a51.gif)

Contact point after:
![circle_correct_contact](https://user-images.githubusercontent.com/17962301/27530901-db774b3c-5a5a-11e7-80c9-d26eecd58175.gif)

I add the normal direction multiplied by `B.r` to `B.p` to get the correct contact point:
```c
c2v n = l != 0 ? c2Mulvs(d, 1.0f / l) : c2V(0, 1.0f);
m->count = 1;
m->depths[ 0 ] = r - l;
m->contact_points[ 0 ] = c2Sub(B.p, c2Mulvs(n, B.r));
m->normal = n;
```