### PR TITLE
tinysound: Add ability to load SDL_RWops

### DIFF
--- a/examples_tinysound/sdl_demo/main.cpp
+++ b/examples_tinysound/sdl_demo/main.cpp
@@ -8,6 +8,11 @@ int main( int argc, char *args[] )
 {
 	tsContext* ctx = tsMakeContext( 0, 44100, 15, 5, 0 );
 	tsLoadedSound loaded = tsLoadWAV( "../jump.wav" );
+
+	// Demo of loading through a SDL_RWops object.
+	//SDL_RWops* file = SDL_RWFromFile( "../jump.wav", "rb");
+	//tsLoadedSound loaded = tsLoadWAVRW(file);
+
 	tsPlayingSound jump = tsMakePlayingSound( &loaded );
 	tsSpawnMixThread( ctx );
 

--- a/tinysound.h
+++ b/tinysound.h
@@ -448,24 +448,27 @@ static void* tsReadFileToMemory( const char* path, int* size )
 // Load an SDL_RWops object's data into memory.
 static void* tsReadRWToMemory( SDL_RWops* rw, int* size )
 {
-	Sint64 res_size = SDL_RWsize(rw);
-	void* data = (void*)malloc(res_size + 1);
+	char* data = 0;
+	int totalSize = 0;
+	int i = 0;
+	char c;
 
-	Sint64 nb_read_total = 0, nb_read = 1;
-	void* buf = data;
-	while ( nb_read_total < res_size && nb_read != 0 ) {
-		nb_read = SDL_RWread(rw, buf, 1, (res_size - nb_read_total));
-		nb_read_total += nb_read;
-		buf += nb_read;
+	while ( SDL_RWread(rw, &c, sizeof(char), 1) > 0 )
+	{
+		totalSize++;
 	}
+
+	data = (char*)malloc(totalSize + 1);
+	memset(data, 0, totalSize + 1);
+	SDL_RWseek(rw, 0, RW_SEEK_SET);
+	while ( SDL_RWread(rw, &c, sizeof(char), 1) > 0 )
+	{
+		data[i++] = c;
+	}
+
 	SDL_RWclose(rw);
-	if ( nb_read_total != res_size ) {
-		free(data);
-		return NULL;
-	}
-
-	if ( size ) *size = (int)res_size;
-	return data;
+	if ( size ) *size = totalSize;
+	return (void*)data;
 }
 #endif
 

--- a/tinysound.h
+++ b/tinysound.h
@@ -258,6 +258,10 @@ typedef struct tsContext tsContext;
 // in the case of errors. Read g_tsErrorReason string for details on what happened.
 // Calls tsReadMemWAV internally.
 tsLoadedSound tsLoadWAV( const char* path );
+#if TS_PLATFORM == TS_SDL
+// Provides the ability to use tsLoadWAV with an SDL_RWops object.
+tsLoadedSound tsLoadWAVRW( SDL_RWops* context );
+#endif
 
 // Reads a WAV file from memory. Still allocates memory for the tsLoadedSound since
 // WAV format will interlace stereo, and we need separate data streams to do SIMD
@@ -269,6 +273,10 @@ void tsReadMemWAV( const void* memory, tsLoadedSound* sound );
 #ifdef STB_VORBIS_INCLUDE_STB_VORBIS_H
 void tsReadMemOGG( const void* memory, int length, int* sample_rate, tsLoadedSound* sound );
 tsLoadedSound tsLoadOGG( const char* path, int* sample_rate );
+#if TS_PLATFORM == TS_SDL
+// Provides the ability to use tsLoadOGG with an SDL_RWops object.
+tsLoadedSound tsLoadOGGRW( SDL_RWops* rw, int* sample_rate );
+#endif
 #endif
 
 // Uses free16 (aligned free, implemented later in this file) to free up both of
@@ -436,6 +444,31 @@ static void* tsReadFileToMemory( const char* path, int* size )
 	return data;
 }
 
+#if TS_PLATFORM == TS_SDL
+// Load an SDL_RWops object's data into memory.
+static void* tsReadRWToMemory( SDL_RWops* rw, int* size )
+{
+	Sint64 res_size = SDL_RWsize(rw);
+	void* data = (void*)malloc(res_size + 1);
+
+	Sint64 nb_read_total = 0, nb_read = 1;
+	void* buf = data;
+	while ( nb_read_total < res_size && nb_read != 0 ) {
+		nb_read = SDL_RWread(rw, buf, 1, (res_size - nb_read_total));
+		nb_read_total += nb_read;
+		buf += nb_read;
+	}
+	SDL_RWclose(rw);
+	if ( nb_read_total != res_size ) {
+		free(data);
+		return NULL;
+	}
+
+	if ( size ) *size = (int)res_size;
+	return data;
+}
+#endif
+
 static int tsFourCC( const char* CC, void* memory )
 {
 	if ( !memcmp( CC, memory, 4 ) ) return 1;
@@ -600,6 +633,17 @@ tsLoadedSound tsLoadWAV( const char* path )
 	return sound;
 }
 
+#if TS_PLATFORM == TS_SDL
+tsLoadedSound tsLoadWAVRW( SDL_RWops* context )
+{
+	tsLoadedSound sound = { 0 };
+	char* wav = (char*)tsReadRWToMemory( context, 0 );
+	tsReadMemWAV( wav, &sound );
+	free( wav );
+	return sound;
+}
+#endif
+
 // If stb_vorbis was included *before* tinysound go ahead and create
 // some functions for dealing with OGG files.
 #ifdef STB_VORBIS_INCLUDE_STB_VORBIS_H
@@ -686,6 +730,19 @@ tsLoadedSound tsLoadOGG( const char* path, int* sample_rate )
 
 	return sound;
 }
+
+#if TS_PLATFORM == TS_SDL
+tsLoadedSound tsLoadOGGRW( SDL_RWops* rw, int* sample_rate )
+{
+	int length;
+	void* memory = tsReadRWToMemory( rw, &length );
+	tsLoadedSound sound;
+	tsReadMemOGG( memory, length, sample_rate, &sound );
+	free( memory );
+
+	return sound;
+}
+#endif
 #endif
 
 void tsFreeSound( tsLoadedSound* sound )

--- a/tinysound.h
+++ b/tinysound.h
@@ -216,6 +216,13 @@
 
 #endif
 
+#if TS_PLATFORM == TS_SDL
+	#ifndef TS_SDL_PATH
+		#define TS_SDL_PATH "SDL2/SDL.h"
+	#endif
+	#include TS_SDL_PATH
+#endif
+
 #include <stdint.h>
 
 // read this in the event of tsLoadWAV/tsLoadOGG errors


### PR DESCRIPTION
This adds the ability to load through [SDL_RWops](https://wiki.libsdl.org/SDL_RWops) objects.

Three new functions:
- `tsLoadWAVRW()`
- `tsLoadOGGRW()`
- `tsReadRWToMemory()`