### PR TITLE
tinysound: Add a Makefile for sdl_demo

### DIFF
--- a/examples_tinysound/sdl_demo/Makefile
+++ b/examples_tinysound/sdl_demo/Makefile
@@ -1,0 +1,5 @@
+OBJS = main.cpp
+OBJ_NAME = sdl_demo
+
+all : $(OBJS)
+	g++ $(OBJS) -w -lSDL2 -o $(OBJ_NAME) -fpermissive


### PR DESCRIPTION
This makes it easier to test out the sdl_demo. Just run `make` to compile sdl_demo.