### PR TITLE
tinysound: Allow changing SDL2/SDL.h path

### DIFF
--- a/tinysound.h
+++ b/tinysound.h
@@ -400,7 +400,10 @@ void tsStopAllSounds( tsContext* ctx );
 
 #else
 
-	#include "SDL2/SDL.h"
+	#ifndef TS_SDL_PATH
+	#define TS_SDL_PATH "SDL2/SDL.h"
+	#endif
+	#include TS_SDL_PATH
 
 #endif
 


### PR DESCRIPTION
This allows to define your own `TS_SDL_PATH` for cases where *SDL2/SDL.h* is not at *SDL2/SDL.h*. Just change the `TS_SDL_PATH` define accordingly.