### PR TITLE
tinyc2: Fix #53, Inconsistent normal direction if using c2Collide

### DIFF
--- a/tinyc2.h
+++ b/tinyc2.h
@@ -478,7 +478,7 @@ void c2Collide( const void* A, const c2x* ax, C2_TYPE typeA, const void* B, cons
 	case C2_AABB:
 		switch ( typeB )
 		{
-		case C2_CIRCLE:  return c2CircletoAABBManifold( *(c2Circle*)B, *(c2AABB*)A, m );
+		case C2_CIRCLE:  c2CircletoAABBManifold( *(c2Circle*)B, *(c2AABB*)A, m ); m->normal = c2Neg( m->normal ); return;
 		case C2_AABB:    return c2AABBtoAABBManifold( *(c2AABB*)A, *(c2AABB*)B, m );
 		case C2_CAPSULE: return c2AABBtoCapsuleManifold( *(c2AABB*)A, *(c2Capsule*)B, m );
 		case C2_POLY:    return c2AABBtoPolyManifold( *(c2AABB*)A, (const c2Poly*)B, bx, m );
@@ -488,8 +488,8 @@ void c2Collide( const void* A, const c2x* ax, C2_TYPE typeA, const void* B, cons
 	case C2_CAPSULE:
 		switch ( typeB )
 		{
-		case C2_CIRCLE:  return c2CircletoCapsuleManifold( *(c2Circle*)B, *(c2Capsule*)A, m );
-		case C2_AABB:    return c2AABBtoCapsuleManifold( *(c2AABB*)B, *(c2Capsule*)A, m );
+		case C2_CIRCLE:  c2CircletoCapsuleManifold( *(c2Circle*)B, *(c2Capsule*)A, m ); m->normal = c2Neg( m->normal ); return;
+		case C2_AABB:    c2AABBtoCapsuleManifold( *(c2AABB*)B, *(c2Capsule*)A, m ); m->normal = c2Neg( m->normal ); return;
 		case C2_CAPSULE: return c2CapsuletoCapsuleManifold( *(c2Capsule*)A, *(c2Capsule*)B, m );
 		case C2_POLY:    return c2CapsuletoPolyManifold( *(c2Capsule*)A, (const c2Poly*)B, bx, m );
 		}
@@ -498,9 +498,9 @@ void c2Collide( const void* A, const c2x* ax, C2_TYPE typeA, const void* B, cons
 	case C2_POLY:
 		switch ( typeB )
 		{
-		case C2_CIRCLE:  return c2CircletoPolyManifold( *(c2Circle*)B, (const c2Poly*)A, ax, m );
-		case C2_AABB:    return c2AABBtoPolyManifold( *(c2AABB*)B, (const c2Poly*)A, ax, m );
-		case C2_CAPSULE: return c2CapsuletoPolyManifold( *(c2Capsule*)A, (const c2Poly*)A, ax, m );
+		case C2_CIRCLE:  c2CircletoPolyManifold( *(c2Circle*)B, (const c2Poly*)A, ax, m ); m->normal = c2Neg( m->normal ); return;
+		case C2_AABB:    c2AABBtoPolyManifold( *(c2AABB*)B, (const c2Poly*)A, ax, m ); m->normal = c2Neg( m->normal ); return;
+		case C2_CAPSULE: c2CapsuletoPolyManifold( *(c2Capsule*)A, (const c2Poly*)A, ax, m ); m->normal = c2Neg( m->normal ); return;
 		case C2_POLY:    return c2PolytoPolyManifold( (const c2Poly*)A, ax, (const c2Poly*)B, bx, m );
 		}
 		break;

--- a/tinyc2.h
+++ b/tinyc2.h
@@ -500,7 +500,7 @@ void c2Collide( const void* A, const c2x* ax, C2_TYPE typeA, const void* B, cons
 		{
 		case C2_CIRCLE:  c2CircletoPolyManifold( *(c2Circle*)B, (const c2Poly*)A, ax, m ); m->normal = c2Neg( m->normal ); return;
 		case C2_AABB:    c2AABBtoPolyManifold( *(c2AABB*)B, (const c2Poly*)A, ax, m ); m->normal = c2Neg( m->normal ); return;
-		case C2_CAPSULE: c2CapsuletoPolyManifold( *(c2Capsule*)A, (const c2Poly*)A, ax, m ); m->normal = c2Neg( m->normal ); return;
+		case C2_CAPSULE: c2CapsuletoPolyManifold( *(c2Capsule*)B, (const c2Poly*)A, ax, m ); m->normal = c2Neg( m->normal ); return;
 		case C2_POLY:    return c2PolytoPolyManifold( (const c2Poly*)A, ax, (const c2Poly*)B, bx, m );
 		}
 		break;


### PR DESCRIPTION
This fixes issue #53 and a typo inside c2Collide.