### PR TITLE
Comment out unused `atan` functions

### DIFF
--- a/tinysound.h
+++ b/tinysound.h
@@ -2140,6 +2140,7 @@ _PI32_CONST( inv1, ~1 );
 _PI32_CONST( 2, 2 );
 _PI32_CONST( 4, 4 );
 
+#if 0 /* temporary comment it out, remove "unused functions" warning */
 static __m128 _mm_atan_ps( __m128 x )
 {
 	__m128 sign_bit, y;
@@ -2246,6 +2247,7 @@ static __m128 _mm_atan2_ps( __m128 y, __m128 x )
 
 	return result;
 }
+#endif
 
 static void _mm_sincos_ps( __m128 x, __m128 *s, __m128 *c )
 {


### PR DESCRIPTION
It's just to remove "unused function" warning