### PR TITLE
Changed TN_UNIX to TF_UNIX

### DIFF
--- a/tinyfiles.h
+++ b/tinyfiles.h
@@ -136,7 +136,7 @@ int tfFileExists( const char* path );
 		FILETIME time;
 	};
 
-#elif TF_PLATFORM == TF_MAC || TF_PLATFORM == TN_UNIX
+#elif TF_PLATFORM == TF_MAC || TF_PLATFORM == TF_UNIX
 
 	#include <sys/stat.h>
 	#include <dirent.h>
@@ -339,7 +339,7 @@ void tfTraverse( const char* path, tfCallback cb, void* udata )
 		return GetFileAttributesExA( path, GetFileExInfoStandard, &unused );
 	}
 
-#elif TF_PLATFORM == TF_MAC || TN_PLATFORM == TN_UNIX
+#elif TF_PLATFORM == TF_MAC || TF_PLATFORM == TF_UNIX
 
 	int tfReadFile( tfDIR* dir, tfFILE* file )
 	{


### PR DESCRIPTION
Fixed inconsistency within TF_PLATFORM preprocessor variables -> Originally defined as TF_PLATFORM and TF_UNIX, but then accessed as TN_PLATFORM and TN_UNIX, causing library to not compile at all