### PR TITLE
tinyc2: Fix contact points and normal in capsule manifolds

### DIFF
--- a/tinyc2.h
+++ b/tinyc2.h
@@ -1276,11 +1276,14 @@ void c2CircletoCapsuleManifold( c2Circle A, c2Capsule B, c2Manifold* m )
 	float d = c2GJK( &A, C2_CIRCLE, 0, &B, C2_CAPSULE, 0, &a, &b, 0 );
 	if ( d < r )
 	{
+		c2v n;
+		if ( d == 0 ) n = c2Norm( c2Skew( c2Sub( B.b, B.a ) ) );
+		else n = c2Norm( c2Sub( b, a ) );
+
 		m->count = 1;
 		m->depths[ 0 ] = r - d;
-		m->contact_points[ 0 ] = c2Mulvs( c2Add( a, b ), 0.5f );
-		if ( d == 0 ) m->normal = c2Skew( c2Norm( c2Sub( B.b, B.a ) ) );
-		else m->normal = c2Norm( c2Sub( b, a ) );
+		m->contact_points[ 0 ] = c2Sub( b, c2Mulvs( n, B.r ) );
+		m->normal = n;
 	}
 }
 

--- a/tinyc2.h
+++ b/tinyc2.h
@@ -1358,13 +1358,18 @@ void c2CapsuletoCapsuleManifold( c2Capsule A, c2Capsule B, c2Manifold* m )
 {
 	m->count = 0;
 	c2v a, b;
+	float r = A.r + B.r;
 	float d = c2GJK( &A, C2_CAPSULE, 0, &B, C2_CAPSULE, 0, &a, &b, 0 );
-	if ( d < A.r + B.r )
+	if ( d < r )
 	{
+		c2v n;
+		if ( d == 0 ) n = c2Norm( c2Skew( c2Sub( A.b, A.a ) ) );
+		else n = c2Norm( c2Sub( b, a ) );
+
 		m->count = 1;
-		m->contact_points[ 0 ] = c2Mulvs( c2Add( a, b ), 0.5f );
-		m->depths[ 0 ] = d;
-		m->normal = d != 0 ? c2Norm( c2Sub( b, a ) ) : c2Norm( c2Skew( c2Sub( A.b, A.a ) ) );
+		m->depths[ 0 ] = r - d;
+		m->contact_points[ 0 ] = c2Sub( b, c2Mulvs( n, B.r ) );
+		m->normal = n;
 	}
 }
 


### PR DESCRIPTION
I found some inconsistencies with contact points in c2CircletoCapsuleManifold:
![circle_capsule_before](https://user-images.githubusercontent.com/17962301/32024740-e436cc56-b9dd-11e7-8ad4-f8b1cec07055.png)
And fixed it:
![circle_capsule_after](https://user-images.githubusercontent.com/17962301/32024756-f3588f94-b9dd-11e7-8f36-8bbdb9dc8d8b.png)

And i found the same inconsistency and a wrong depth calculation in c2CapsuletoCapsuleManifold:
![capsule_capsule_before](https://user-images.githubusercontent.com/17962301/32024817-244ad5a8-b9de-11e7-9e32-86f86e5bc985.png)
And fixed it:
![capsule_capsule_after](https://user-images.githubusercontent.com/17962301/32024824-2a45d192-b9de-11e7-9958-333f96bd3ee9.png)




