### PR TITLE
tinypath: Implement tpCompact

### DIFF
--- a/tinypath.h
+++ b/tinypath.h
@@ -86,8 +86,9 @@ void tpDoUnitTests();
 
 #endif
 
-#include <string.h> // strncpy, strlen
+#include <string.h> // strncpy, strncat, strlen
 #define TP_STRNCPY strncpy
+#define TP_STRNCAT strncat
 #define TP_STRLEN strlen
 
 int tpIsSlash( char c )
@@ -253,7 +254,7 @@ int tpCompact( const char* path, char* out, int n )
 
 	if ( pathlen <= n )
 	{
-		strncpy( out, path, pathlen );
+		TP_STRNCPY( out, path, pathlen );
 		out[ pathlen ] = 0;
 		return pathlen;
 	}
@@ -272,35 +273,35 @@ int tpCompact( const char* path, char* out, int n )
 	// No path separator was found or the first character was one
 	if ( pathlen == backlen )
 	{
-		strncpy( out, path, n - seplen );
+		TP_STRNCPY( out, path, n - seplen );
 		out[ n - seplen ] = 0;
-		strncat( out, sep, seplen + 1 );
+		TP_STRNCAT( out, sep, seplen + 1 );
 		return n;
 	}
 
 	// Last path part with separators in front equals n
 	if ( backlen == n - seplen )
 	{
-		strncpy( out, sep, seplen + 1 );
-		strncat( out, back, backlen );
+		TP_STRNCPY( out, sep, seplen + 1 );
+		TP_STRNCAT( out, back, backlen );
 		return n;
 	}
 
 	// Last path part with separators in front is too long
 	if ( backlen > n - seplen )
 	{
-		strncpy( out, sep, seplen + 1 );
-		strncat( out, back, n - ( 2 * seplen ) );
-		strncat( out, sep, seplen );
+		TP_STRNCPY( out, sep, seplen + 1 );
+		TP_STRNCAT( out, back, n - ( 2 * seplen ) );
+		TP_STRNCAT( out, sep, seplen );
 		return n;
 	}
 
 	int remaining = n - backlen - seplen;
 
-	strncpy( out, path, remaining );
+	TP_STRNCPY( out, path, remaining );
 	out[ remaining ] = 0;
-	strncat( out, sep, seplen );
-	strncat( out, back, backlen );
+	TP_STRNCAT( out, sep, seplen );
+	TP_STRNCAT( out, back, backlen );
 
 	return 1;
 }

--- a/tinypath.h
+++ b/tinypath.h
@@ -246,6 +246,8 @@ int tpNameOfFolderImIn( const char* path, char* out )
 
 int tpCompact( const char* path, char* out, int n )
 {
+	if (n <= 6) return 0;
+
 	const char* sep = "...";
 	const int seplen = strlen( sep );
 

--- a/tinypath.h
+++ b/tinypath.h
@@ -282,7 +282,7 @@ int tpCompact( const char* path, char* out, int n )
 	if ( backlen == n - seplen )
 	{
 		strncpy( out, sep, seplen + 1 );
-		strcat( out, back ); // TODO: use strncat
+		strncat( out, back, backlen );
 		return n;
 	}
 
@@ -300,7 +300,7 @@ int tpCompact( const char* path, char* out, int n )
 	strncpy( out, path, remaining );
 	out[ remaining ] = 0;
 	strncat( out, sep, seplen );
-	strcat( out, back ); // TODO: use strncat
+	strncat( out, back, backlen );
 
 	return 1;
 }

--- a/tinypath.h
+++ b/tinypath.h
@@ -62,10 +62,10 @@ void tpConcat( const char* path_a, const char* path_b, char* out, int max_buffer
 // Returns 0 for inputs of "", "." or ".." as the path, 1 otherwise (success).
 int tpNameOfFolderImIn( const char* path, char* out );
 
-// Shrinks the path to the desired length n, the out buffer will never be bigger than n.
-// Places three '.' between the last part of the path and the first part that will be
-// shortened to fit. If the last part is too long to fit in a string of length n, the
-// last part will be shortened to fit and three '.' will be added in front & back.
+// Shrinks the path to the desired length n, the out buffer will never be bigger than
+// n + 1. Places three '.' between the last part of the path and the first part that
+// will be shortened to fit. If the last part is too long to fit in a string of length n,
+// the last part will be shortened to fit and three '.' will be added in front & back.
 int tpCompact( const char* path, char* out, int n );
 
 // Some useful (but not yet implemented) functions

--- a/tinypath.h
+++ b/tinypath.h
@@ -62,6 +62,10 @@ void tpConcat( const char* path_a, const char* path_b, char* out, int max_buffer
 // Returns 0 for inputs of "", "." or ".." as the path, 1 otherwise (success).
 int tpNameOfFolderImIn( const char* path, char* out );
 
+// Shrinks the path to the desired length n, the out buffer will never be bigger than n.
+// Places three '.' between the last part of the path and the first part that will be
+// shortened to fit. If the last part is too long to fit in a string of length n, the
+// last part will be shortened to fit and three '.' will be added in front & back.
 int tpCompact( const char* path, char* out, int n );
 
 // Some useful (but not yet implemented) functions

--- a/tinypath.h
+++ b/tinypath.h
@@ -324,6 +324,7 @@ int tpCompact( const char* path, char* out, int n )
 		char out[ TP_MAX_PATH ];
                 char pop[ TP_MAX_PATH ];
                 char ext[ TP_MAX_PATH ];
+                int n;
 
 		const char* path = "../root/file.ext";
 		tpPopExt( path, out, ext );
@@ -455,28 +456,34 @@ int tpCompact( const char* path, char* out, int n )
 		TP_EXPECT( !TP_STRCMP( out, "a/b/c/d/e/f/g/h/i" ) );
 
 		path = "/path/to/file.vim";
-		tpCompact( path, out, 17 );
+		n = tpCompact( path, out, 17 );
 		TP_EXPECT( !TP_STRCMP( out, "/path/to/file.vim" ) );
+		TP_EXPECT( n == TP_STRLEN( out ) );
 
 		path = "/path/to/file.vim";
-		tpCompact( path, out, 16 );
+		n = tpCompact( path, out, 16 );
 		TP_EXPECT( !TP_STRCMP( out, "/pat.../file.vim" ) );
+		TP_EXPECT( n == TP_STRLEN( out ) );
 
 		path = "/path/to/file.vim";
-		tpCompact( path, out, 12 );
+		n = tpCompact( path, out, 12 );
 		TP_EXPECT( !TP_STRCMP( out, ".../file.vim" ) );
+		TP_EXPECT( n == TP_STRLEN( out ) );
 
 		path = "/path/to/file.vim";
-		tpCompact( path, out, 11 );
+		n = tpCompact( path, out, 11 );
 		TP_EXPECT( !TP_STRCMP( out, ".../file..." ) );
+		TP_EXPECT( n == TP_STRLEN( out ) );
 
 		path = "longfile.vim";
-		tpCompact( path, out, 12 );
+		n = tpCompact( path, out, 12 );
 		TP_EXPECT( !TP_STRCMP( out, "longfile.vim" ) );
+		TP_EXPECT( n == TP_STRLEN( out ) );
 
 		path = "longfile.vim";
-		tpCompact( path, out, 11 );
+		n = tpCompact( path, out, 11 );
 		TP_EXPECT( !TP_STRCMP( out, "longfile..." ) );
+		TP_EXPECT( n == TP_STRLEN( out ) );
 	}
 
 #else

--- a/tinypath.h
+++ b/tinypath.h
@@ -309,7 +309,7 @@ int tpCompact( const char* path, char* out, int n )
 	TP_STRNCAT( out, sep, seplen );
 	TP_STRNCAT( out, back, backlen );
 
-	return 1;
+	return n;
 }
 
 #if TP_UNIT_TESTS

--- a/tinypath.h
+++ b/tinypath.h
@@ -62,7 +62,7 @@ void tpConcat( const char* path_a, const char* path_b, char* out, int max_buffer
 // Returns 0 for inputs of "", "." or ".." as the path, 1 otherwise (success).
 int tpNameOfFolderImIn( const char* path, char* out );
 
-int tpCompact( const char* path, int length, char* out );
+int tpCompact( const char* path, char* out int length );
 
 // Some useful (but not yet implemented) functions
 /*
@@ -243,19 +243,19 @@ int tpNameOfFolderImIn( const char* path, char* out )
 	return 1;
 }
 
-int tpCompact( const char* path, int length, char* out )
+int tpCompact( const char* path, char* out, int n )
 {
 	const char* sep = "...";
 	const int seplen = strlen( separator );
 
 	int pathlen = strlen( path );
-	out[0] = '\0';
+	out[ 0 ] = '\0';
 
-	if (pathlen <= length)
+	if ( pathlen <= n )
 	{
-		strncpy(out, path, length);
-		out[length] = '\0';
-		return 1;
+		strncpy( out, path, pathlen );
+		out[ pathlen ] = '\0';
+		return pathlen;
 	}
 
 	// Find last path separator
@@ -264,40 +264,43 @@ int tpCompact( const char* path, int length, char* out )
 	do
 	{
 		--i;
-	} while (!tpIsSlash(path[i]) && i > 0);
+	} while ( !tpIsSlash( path[ i ] ) && i > 0 );
 
-	int backlen = strlen(path + i);
+	const char* back = path + i;
+	int backlen = strlen( back );
 
 	// No path separator was found or the first character was one
-	if (pathlen == backlen)
+	if ( pathlen == backlen )
 	{
-		strncpy(out, path, l - seplen);
-		out[l - seplen] = '\0';
-		strncat(out, sep, seplen + 1);
-		return 1;
+		strncpy( out, path, n - seplen );
+		out[ n - seplen ] = '\0';
+		strncat( out, sep, seplen + 1 );
+		return n;
 	}
 
-	// Last path part with separators in front equals length
-	if (backlen == l - seplen) {
-		strncpy(out, sep, seplen + 1);
-		strcat(out, path + i); // TODO: use strncat
-		return 1;
+	// Last path part with separators in front equals n
+	if ( backlen == n - seplen )
+	{
+		strncpy( out, sep, seplen + 1 );
+		strcat( out, back ); // TODO: use strncat
+		return n;
 	}
 
 	// Last path part with separators in front is too long
-	if (backlen > l - seplen) {
-		strncpy(out, sep, seplen + 1);
-		strncat(out, path + i, l - (2 * seplen));
-		strncat(out, sep, seplen);
-		return 1;
+	if ( backlen > n - seplen )
+	{
+		strncpy( out, sep, seplen + 1 );
+		strncat( out, back, n - ( 2 * seplen ) );
+		strncat( out, sep, seplen );
+		return n;
 	}
 
-	int remaining = l - backlen - seplen;
+	int remaining = n - backlen - seplen;
 
-	strncpy(out, path, remaining);
-	out[remaining] = '\0';
-	strncat(out, sep, seplen);
-	strcat(out, path + i); // TODO: use strncat
+	strncpy( out, path, remaining );
+	out[ remaining ] = '\0';
+	strncat( out, sep, seplen );
+	strcat( out, back ); // TODO: use strncat
 
 	return 1;
 }

--- a/tinypath.h
+++ b/tinypath.h
@@ -249,12 +249,12 @@ int tpCompact( const char* path, char* out, int n )
 	const int seplen = strlen( sep );
 
 	int pathlen = strlen( path );
-	out[ 0 ] = '\0';
+	out[ 0 ] = 0;
 
 	if ( pathlen <= n )
 	{
 		strncpy( out, path, pathlen );
-		out[ pathlen ] = '\0';
+		out[ pathlen ] = 0;
 		return pathlen;
 	}
 
@@ -273,7 +273,7 @@ int tpCompact( const char* path, char* out, int n )
 	if ( pathlen == backlen )
 	{
 		strncpy( out, path, n - seplen );
-		out[ n - seplen ] = '\0';
+		out[ n - seplen ] = 0;
 		strncat( out, sep, seplen + 1 );
 		return n;
 	}
@@ -298,7 +298,7 @@ int tpCompact( const char* path, char* out, int n )
 	int remaining = n - backlen - seplen;
 
 	strncpy( out, path, remaining );
-	out[ remaining ] = '\0';
+	out[ remaining ] = 0;
 	strncat( out, sep, seplen );
 	strcat( out, back ); // TODO: use strncat
 

--- a/tinypath.h
+++ b/tinypath.h
@@ -62,7 +62,7 @@ void tpConcat( const char* path_a, const char* path_b, char* out, int max_buffer
 // Returns 0 for inputs of "", "." or ".." as the path, 1 otherwise (success).
 int tpNameOfFolderImIn( const char* path, char* out );
 
-int tpCompact( const char* path, char* out int length );
+int tpCompact( const char* path, char* out, int n );
 
 // Some useful (but not yet implemented) functions
 /*
@@ -246,7 +246,7 @@ int tpNameOfFolderImIn( const char* path, char* out )
 int tpCompact( const char* path, char* out, int n )
 {
 	const char* sep = "...";
-	const int seplen = strlen( separator );
+	const int seplen = strlen( sep );
 
 	int pathlen = strlen( path );
 	out[ 0 ] = '\0';


### PR DESCRIPTION
I had a look at `tpPop` but it didn't really fit the problem so i decided to do it without. I added some tests to cover the special cases i found. I made a requirement for n to be bigger than 6, in some cases 3 would be enough but i think 6 is reasonable.

Some examples with "/path/to/file.vim":
```
n = 17: "/path/to/file.vim"
n = 16: "/pat.../file.vim"
n = 12: ".../file.vim"
n = 11: ".../file..."
```
more examples are in the tests.

I also added tests for the return value of `tpCompact`