### PR TITLE
Typo in #defines and Missing #include for time.h

### DIFF
--- a/tinyfiles.h
+++ b/tinyfiles.h
@@ -440,7 +440,7 @@ int tfMatchExt( tfFILE* file, const char* ext )
 		if ( stat( path_a, &info ) ) return 0;
 		time_a = info.st_mtime;
 		if ( stat( path_b, &info ) ) return 0;
-		time_a = info.st_mtime;
+		time_b = info.st_mtime;
 		return (int)difftime( time_a, time_b );
 	}
 

--- a/tinyfiles.h
+++ b/tinyfiles.h
@@ -157,6 +157,7 @@ void tfDoUnitTests();
 	#include <sys/stat.h>
 	#include <dirent.h>
 	#include <unistd.h>
+    #include <time.h>
 
 	struct tfFILE
 	{

--- a/tinyfiles.h
+++ b/tinyfiles.h
@@ -152,7 +152,7 @@ void tfDoUnitTests();
 		FILETIME time;
 	};
 
-#elif TF_PLATFORM == TF_MAC || TF_PLATFORM == TN_UNIX
+#elif TF_PLATFORM == TF_MAC || TF_PLATFORM == TF_UNIX
 
 	#include <sys/stat.h>
 	#include <dirent.h>
@@ -363,7 +363,7 @@ int tfMatchExt( tfFILE* file, const char* ext )
 		return GetFileAttributesExA( path, GetFileExInfoStandard, &unused );
 	}
 
-#elif TF_PLATFORM == TF_MAC || TN_PLATFORM == TN_UNIX
+#elif TF_PLATFORM == TF_MAC || TF_PLATFORM == TF_UNIX
 
 	int tfReadFile( tfDIR* dir, tfFILE* file )
 	{


### PR DESCRIPTION
The #defines were referenced in #59 and fixed in #61 but somehow they snuck back in.

The missing `#include <time.h>` caused a compilation error on Linux due to the use of `difftime()`

I also noticed that time_a is overwritten [here](https://github.com/RandyGaul/tinyheaders/blob/master/tinyfiles.h#L442) instead of assing path_b's time to time_b. I haven't used this function, but I figured that's what you were going for.